### PR TITLE
Create vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,11 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "has": [
+        { "type": "host", "value": "domain.com" }
+      ],
+      "destination": "/"
+    }
+  ]
+}


### PR DESCRIPTION
Fixed Vercel saying `404: Not Fount` when going to `/dashboard/login`

Tells Vercel to serve `index.html` for all routes

This rewrites all requests to `/` (so Vercel serves `index.html`), and then your React app’s router decides which component to render (like `/dashboard/login` → `<DashboardLogin />`).